### PR TITLE
fix/feat: CDI datasource-free support, H2 dialect detection, erasure receipt foundation

### DIFF
--- a/api/src/main/java/io/casehub/ledger/api/model/ErasureReason.java
+++ b/api/src/main/java/io/casehub/ledger/api/model/ErasureReason.java
@@ -1,0 +1,19 @@
+package io.casehub.ledger.api.model;
+
+/**
+ * Why a GDPR Art.17 erasure was performed.
+ *
+ * <p>Stored on {@link io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry}
+ * to make the legal basis for each erasure event queryable and auditable.
+ */
+public enum ErasureReason {
+
+    /** Subject exercised the Art.17 right-to-erasure. */
+    GDPR_ART_17_REQUEST,
+
+    /** Automated retention policy expired the actor's data window. */
+    RETENTION_EXPIRED,
+
+    /** Account deletion triggered erasure of all associated ledger identity mappings. */
+    ACCOUNT_DELETION
+}

--- a/persistence-memory/src/main/java/io/casehub/ledger/memory/InMemoryErasureReceiptRepository.java
+++ b/persistence-memory/src/main/java/io/casehub/ledger/memory/InMemoryErasureReceiptRepository.java
@@ -1,0 +1,34 @@
+package io.casehub.ledger.memory;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+
+import io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry;
+import io.casehub.ledger.runtime.repository.ErasureReceiptRepository;
+
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class InMemoryErasureReceiptRepository implements ErasureReceiptRepository {
+
+    @Inject
+    InMemoryLedgerEntryRepository blocking;
+
+    @Override
+    public List<ErasureReceiptLedgerEntry> findByErasedActorId(
+            final String erasedActorId, final String tenancyId) {
+        return blocking.allEntries().stream()
+                .filter(e -> e instanceof ErasureReceiptLedgerEntry)
+                .map(e -> (ErasureReceiptLedgerEntry) e)
+                .filter(e -> erasedActorId.equals(e.erasedActorId))
+                .filter(e -> tenancyId.equals(e.tenancyId))
+                .sorted(Comparator.comparing(e -> e.occurredAt))
+                .collect(Collectors.toList());
+    }
+}

--- a/persistence-memory/src/test/resources/application.properties
+++ b/persistence-memory/src/test/resources/application.properties
@@ -12,7 +12,8 @@ quarkus.arc.selected-alternatives=\
   io.casehub.ledger.memory.InMemoryLedgerMerkleFrontierRepository,\
   io.casehub.ledger.memory.InMemoryActorTrustScoreRepository,\
   io.casehub.ledger.memory.InMemoryKeyRotationRepository,\
-  io.casehub.ledger.memory.InMemoryAgentSigner
+  io.casehub.ledger.memory.InMemoryAgentSigner,\
+  io.casehub.ledger.memory.InMemoryErasureReceiptRepository
 
 casehub.ledger.enabled=true
 casehub.ledger.hash-chain.enabled=true

--- a/runtime/src/main/java/io/casehub/ledger/runtime/config/LedgerConfig.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/config/LedgerConfig.java
@@ -138,6 +138,13 @@ public interface LedgerConfig {
     OutcomeConfig outcome();
 
     /**
+     * Erasure receipt settings — opt-in tamper-evident GDPR Art.17 erasure records.
+     *
+     * @return erasure receipt sub-configuration
+     */
+    ErasureReceiptConfig erasureReceipt();
+
+    /**
      * Reactive service tier — controls whether {@code ReactiveKeyRotationService} and
      * {@code ReactiveAgentSignatureVerificationService} are present in the CDI graph. Set
      * {@code casehub.ledger.reactive.enabled=true} only in deployments that provide a
@@ -736,5 +743,23 @@ public interface LedgerConfig {
          */
         @WithDefault("SYSTEM")
         io.casehub.platform.api.identity.ActorType defaultAttestorType();
+    }
+
+    /** Erasure receipt settings. */
+    interface ErasureReceiptConfig {
+
+        /**
+         * When {@code true}, {@code LedgerErasureService.erase()} writes an
+         * {@link io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry} to the Merkle
+         * chain on every erasure call — making the act of forgetting tamper-evident.
+         * The receipt is queryable via {@link io.casehub.ledger.runtime.repository.ErasureReceiptRepository}.
+         *
+         * <p>Off by default — enabling requires {@code JpaErasureReceiptRepository} (or the
+         * in-memory alternative) to be on the CDI path and the V1009 migration to be applied.
+         *
+         * @return {@code true} if erasure receipt writing is active; {@code false} by default
+         */
+        @WithDefault("false")
+        boolean enabled();
     }
 }

--- a/runtime/src/main/java/io/casehub/ledger/runtime/model/ErasureReceiptLedgerEntry.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/model/ErasureReceiptLedgerEntry.java
@@ -1,0 +1,74 @@
+package io.casehub.ledger.runtime.model;
+
+import java.nio.charset.StandardCharsets;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+
+import io.casehub.ledger.api.model.ErasureReason;
+
+/**
+ * A first-class immutable ledger entry recording a GDPR Art.17 erasure event.
+ *
+ * <p>Opt-in: written by {@code LedgerErasureService} when
+ * {@code casehub.ledger.erasure.receipt.enabled=true}. The receipt is part of the
+ * Merkle chain — the act of forgetting is itself tamper-evident.
+ *
+ * <p>{@link #subjectId} is derived deterministically as
+ * {@code UUID.nameUUIDFromBytes(erasedActorId.getBytes(UTF_8))}, making the full
+ * erasure history for an actor queryable as an ordered ledger sequence — identical
+ * to the convention used by {@link KeyRotationEntry} and {@link ActorIdentityBindingEntry}.
+ *
+ * <p>{@link #erasedActorId} stores the raw identity that was erased. This is intentional:
+ * after erasure, the receipt is the only tamper-evident proof that erasure happened for
+ * a specific actor. Retaining this proof is a GDPR compliance obligation, not a violation.
+ *
+ * <p>{@link #entryType} is set to {@link io.casehub.ledger.api.model.LedgerEntryType#EVENT}
+ * by {@code LedgerErasureService} before persist.
+ */
+@NamedQueries({
+    @NamedQuery(
+        name = "ErasureReceiptLedgerEntry.findByErasedActorId",
+        query = "SELECT e FROM ErasureReceiptLedgerEntry e " +
+                "WHERE e.erasedActorId = :erasedActorId AND e.tenancyId = :tenancyId " +
+                "ORDER BY e.occurredAt ASC")
+})
+@Entity
+@Table(name = "erasure_receipt_entry")
+@DiscriminatorValue("ERASURE_RECEIPT")
+public class ErasureReceiptLedgerEntry extends LedgerEntry {
+
+    /** The raw actor identity that was erased. Stored before the token→identity mapping is severed. */
+    @Column(name = "erased_actor_id", nullable = false)
+    public String erasedActorId;
+
+    /** The legal basis or trigger for this erasure event. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "erasure_reason", nullable = false)
+    public ErasureReason erasureReason;
+
+    /** Count of ledger entries whose {@code actorId} was the severed token. Informational. */
+    @Column(name = "affected_entry_count", nullable = false)
+    public long affectedEntryCount;
+
+    /** Whether a token→identity mapping actually existed and was severed. */
+    @Column(name = "mapping_found", nullable = false)
+    public boolean mappingFound;
+
+    @Override
+    protected byte[] domainContentBytes() {
+        final String content = String.join("|",
+            erasedActorId != null ? erasedActorId : "",
+            erasureReason != null ? erasureReason.name() : "",
+            String.valueOf(affectedEntryCount),
+            String.valueOf(mappingFound)
+        );
+        return content.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/runtime/src/main/java/io/casehub/ledger/runtime/privacy/LedgerErasureService.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/privacy/LedgerErasureService.java
@@ -1,15 +1,27 @@
 package io.casehub.ledger.runtime.privacy;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 
+import io.casehub.ledger.api.model.ErasureReason;
 import io.casehub.ledger.api.spi.ActorIdentityProvider;
+import io.casehub.ledger.api.model.LedgerEntryType;
+import io.casehub.ledger.runtime.config.LedgerConfig;
 import io.casehub.ledger.runtime.model.ActorIdentity;
+import io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry;
 import io.casehub.ledger.runtime.persistence.LedgerPersistenceUnit;
+import io.casehub.ledger.runtime.repository.LedgerEntryRepository;
+import io.casehub.platform.api.identity.ActorType;
+import io.casehub.platform.api.identity.TenancyConstants;
 
 /**
  * CDI bean for processing GDPR Art.17 erasure requests.
@@ -18,6 +30,11 @@ import io.casehub.ledger.runtime.persistence.LedgerPersistenceUnit;
  * Severs the token→identity mapping for the given actor. Ledger entries retaining
  * the token become permanently anonymous — the hash chain is intact; the personal
  * data link is gone. Returns an {@link ErasureResult} with diagnostic information.
+ *
+ * <p>
+ * When {@code casehub.ledger.erasure.receipt.enabled=true}, a tamper-evident
+ * {@link ErasureReceiptLedgerEntry} is written to the Merkle chain in the same
+ * transaction. This makes the act of forgetting provable and auditable.
  */
 @ApplicationScoped
 public class LedgerErasureService {
@@ -29,6 +46,12 @@ public class LedgerErasureService {
     @LedgerPersistenceUnit
     EntityManager em;
 
+    @Inject
+    LedgerEntryRepository ledger;
+
+    @Inject
+    LedgerConfig config;
+
     /**
      * The outcome of an erasure request.
      *
@@ -36,8 +59,14 @@ public class LedgerErasureService {
      * @param mappingFound {@code true} if a token→identity mapping existed and was severed
      * @param affectedEntryCount number of ledger entries whose {@code actorId} was the severed token;
      *        informational only — entries are not deleted
+     * @param receiptEntryId UUID of the written {@link ErasureReceiptLedgerEntry}, when
+     *        {@code casehub.ledger.erasure.receipt.enabled=true}; empty otherwise
      */
-    public record ErasureResult(String rawActorId, boolean mappingFound, long affectedEntryCount) {
+    public record ErasureResult(
+            String rawActorId,
+            boolean mappingFound,
+            long affectedEntryCount,
+            Optional<UUID> receiptEntryId) {
     }
 
     /**
@@ -47,29 +76,66 @@ public class LedgerErasureService {
      * If no mapping exists (tokenisation was never enabled for this actor, or the identity
      * was already erased), returns {@code mappingFound=false} with count 0.
      *
+     * <p>
+     * When {@code casehub.ledger.erasure.receipt.enabled=true}, an
+     * {@link ErasureReceiptLedgerEntry} is written regardless of whether a mapping was found —
+     * the receipt records that an erasure was attempted.
+     *
      * @param rawActorId the real actor identity to erase
+     * @param reason the legal basis or trigger for this erasure
      * @return the erasure result
      */
     @Transactional
-    public ErasureResult erase(final String rawActorId) {
+    public ErasureResult erase(final String rawActorId, final ErasureReason reason) {
         final List<ActorIdentity> existing = em
                 .createNamedQuery("ActorIdentity.findByActorId", ActorIdentity.class)
                 .setParameter("actorId", rawActorId)
                 .getResultList();
 
-        if (existing.isEmpty()) {
-            return new ErasureResult(rawActorId, false, 0L);
+        final boolean mappingFound = !existing.isEmpty();
+
+        final long count;
+        if (mappingFound) {
+            final String token = existing.get(0).token;
+            count = em
+                    .createQuery("SELECT COUNT(e) FROM LedgerEntry e WHERE e.actorId = :token",
+                            Long.class)
+                    .setParameter("token", token)
+                    .getSingleResult();
+            actorIdentityProvider.erase(rawActorId);
+        } else {
+            count = 0L;
         }
 
-        final String token = existing.get(0).token;
+        final Optional<UUID> receiptEntryId;
+        if (config.erasureReceipt().enabled()) {
+            final ErasureReceiptLedgerEntry receipt = buildReceipt(
+                    rawActorId, reason, mappingFound, count);
+            ledger.save(receipt, TenancyConstants.DEFAULT_TENANT_ID);
+            receiptEntryId = Optional.of(receipt.id);
+        } else {
+            receiptEntryId = Optional.empty();
+        }
 
-        final long count = em
-                .createQuery("SELECT COUNT(e) FROM LedgerEntry e WHERE e.actorId = :token", Long.class)
-                .setParameter("token", token)
-                .getSingleResult();
+        return new ErasureResult(rawActorId, mappingFound, count, receiptEntryId);
+    }
 
-        actorIdentityProvider.erase(rawActorId);
-
-        return new ErasureResult(rawActorId, true, count);
+    private ErasureReceiptLedgerEntry buildReceipt(
+            final String rawActorId,
+            final ErasureReason reason,
+            final boolean mappingFound,
+            final long affectedEntryCount) {
+        final ErasureReceiptLedgerEntry receipt = new ErasureReceiptLedgerEntry();
+        receipt.subjectId = UUID.nameUUIDFromBytes(rawActorId.getBytes(StandardCharsets.UTF_8));
+        receipt.entryType = LedgerEntryType.EVENT;
+        receipt.actorId = "system:ledger-erasure";
+        receipt.actorType = ActorType.SYSTEM;
+        receipt.actorRole = "ErasureService";
+        receipt.occurredAt = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        receipt.erasedActorId = rawActorId;
+        receipt.erasureReason = reason;
+        receipt.mappingFound = mappingFound;
+        receipt.affectedEntryCount = affectedEntryCount;
+        return receipt;
     }
 }

--- a/runtime/src/main/java/io/casehub/ledger/runtime/privacy/LedgerPrivacyProducer.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/privacy/LedgerPrivacyProducer.java
@@ -1,6 +1,7 @@
 package io.casehub.ledger.runtime.privacy;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -31,14 +32,14 @@ public class LedgerPrivacyProducer {
 
     @Inject
     @LedgerPersistenceUnit
-    EntityManager em;
+    Instance<EntityManager> emInstance;
 
     @Produces
     @DefaultBean
     @ApplicationScoped
     public ActorIdentityProvider actorIdentityProvider() {
         if (config.identity().tokenisation().enabled()) {
-            return new InternalActorIdentityProvider(em);
+            return new InternalActorIdentityProvider(emInstance.get());
         }
         return new PassThroughActorIdentityProvider();
     }

--- a/runtime/src/main/java/io/casehub/ledger/runtime/repository/ErasureReceiptRepository.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/repository/ErasureReceiptRepository.java
@@ -1,0 +1,22 @@
+package io.casehub.ledger.runtime.repository;
+
+import java.util.List;
+
+import io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry;
+
+/**
+ * SPI for querying {@link ErasureReceiptLedgerEntry} records.
+ *
+ * <p>Receipt entries are persisted via
+ * {@link LedgerEntryRepository#save(io.casehub.ledger.runtime.model.LedgerEntry, String)},
+ * which ensures Merkle chain inclusion, pseudonymisation, and enricher pipeline execution.
+ * This SPI covers read access only.
+ */
+public interface ErasureReceiptRepository {
+
+    /**
+     * All erasure receipts for the given raw actor identity within the given tenant,
+     * ordered by {@code occurredAt} ascending.
+     */
+    List<ErasureReceiptLedgerEntry> findByErasedActorId(String erasedActorId, String tenancyId);
+}

--- a/runtime/src/main/java/io/casehub/ledger/runtime/repository/NoOpErasureReceiptRepository.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/repository/NoOpErasureReceiptRepository.java
@@ -1,0 +1,31 @@
+package io.casehub.ledger.runtime.repository;
+
+import java.util.List;
+
+import io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry;
+import io.quarkus.arc.DefaultBean;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * No-op {@link ErasureReceiptRepository} — satisfies the CDI injection point when
+ * neither {@code JpaErasureReceiptRepository} nor the in-memory alternative is active.
+ *
+ * <p>Activation priority (lowest to highest):
+ * <ol>
+ * <li>This {@code @DefaultBean} — active when nothing else is present</li>
+ * <li>{@code JpaErasureReceiptRepository @Alternative} — activate via
+ *     {@code quarkus.arc.selected-alternatives}</li>
+ * <li>{@code InMemoryErasureReceiptRepository @Alternative @Priority(1)} —
+ *     active when {@code casehub-ledger-memory} is on the classpath</li>
+ * </ol>
+ */
+@DefaultBean
+@ApplicationScoped
+public class NoOpErasureReceiptRepository implements ErasureReceiptRepository {
+
+    @Override
+    public List<ErasureReceiptLedgerEntry> findByErasedActorId(
+            final String erasedActorId, final String tenancyId) {
+        return List.of();
+    }
+}

--- a/runtime/src/main/java/io/casehub/ledger/runtime/repository/jpa/JpaErasureReceiptRepository.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/repository/jpa/JpaErasureReceiptRepository.java
@@ -1,0 +1,38 @@
+package io.casehub.ledger.runtime.repository.jpa;
+
+import java.util.List;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+
+import io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry;
+import io.casehub.ledger.runtime.persistence.LedgerPersistenceUnit;
+import io.casehub.ledger.runtime.repository.ErasureReceiptRepository;
+
+/**
+ * JPA implementation of {@link ErasureReceiptRepository}.
+ *
+ * <p>Activate via {@code quarkus.arc.selected-alternatives}.
+ * When neither this nor the in-memory alternative is active,
+ * {@link io.casehub.ledger.runtime.repository.NoOpErasureReceiptRepository} handles reads.
+ */
+@Alternative
+@ApplicationScoped
+public class JpaErasureReceiptRepository implements ErasureReceiptRepository {
+
+    @Inject
+    @LedgerPersistenceUnit
+    EntityManager em;
+
+    @Override
+    public List<ErasureReceiptLedgerEntry> findByErasedActorId(
+            final String erasedActorId, final String tenancyId) {
+        return em.createNamedQuery(
+                "ErasureReceiptLedgerEntry.findByErasedActorId", ErasureReceiptLedgerEntry.class)
+                .setParameter("erasedActorId", erasedActorId)
+                .setParameter("tenancyId", tenancyId)
+                .getResultList();
+    }
+}

--- a/runtime/src/main/java/io/casehub/ledger/runtime/repository/jpa/LedgerSequenceAllocator.java
+++ b/runtime/src/main/java/io/casehub/ledger/runtime/repository/jpa/LedgerSequenceAllocator.java
@@ -1,35 +1,40 @@
 package io.casehub.ledger.runtime.repository.jpa;
 
+import java.util.Locale;
 import java.util.UUID;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
+import org.hibernate.Session;
+
 import io.casehub.ledger.runtime.persistence.LedgerPersistenceUnit;
 
 /**
  * Atomically allocates per-subject sequence numbers from the {@code ledger_subject_sequence} table.
  *
- * <p>Uses {@code INSERT ... ON CONFLICT DO NOTHING} followed by
- * {@code UPDATE SET next_seq = next_seq + 1}. Both H2 2.2+ (in {@code MODE=PostgreSQL}) and
- * PostgreSQL support this syntax. H2's grammar accepts only the no-column-target form
- * ({@code ON CONFLICT DO NOTHING}); PostgreSQL accepts both forms. Using the no-column-target
- * form is valid for both: the {@code ledger_subject_sequence} table has exactly one unique
- * constraint (the PK on {@code (subject_id, tenancy_id)}), so the target is unambiguous.
+ * <p><strong>Dialect selection:</strong> detected once at first use via JDBC metadata and cached
+ * for the application lifetime.
  *
- * <p><strong>Concurrent first-insert safety:</strong> when two transactions race for a new
- * {@code (subjectId, tenancyId)} pair, exactly one INSERT creates the row; the other silently
- * does nothing (DO NOTHING suppresses the unique-constraint violation rather than propagating it).
- * Both transactions then issue the UPDATE, which serialises on the row lock held by whichever
- * transaction arrived first. The loser blocks at the UPDATE until the winner commits.
+ * <ul>
+ *   <li><b>PostgreSQL and H2 in {@code MODE=PostgreSQL}</b>: {@code INSERT ON CONFLICT DO NOTHING}
+ *   + {@code UPDATE}. The INSERT seeds the row on first use; concurrent first-inserts are safe —
+ *   one wins, the other silently does nothing, both then serialise on the UPDATE row lock. The row
+ *   lock is held for the enclosing {@code @Transactional save()}, which is the Merkle
+ *   Serialization Invariant: saves to the same {@code (subject, tenancy)} pair are fully
+ *   serialised including the Merkle frontier update.</li>
+ *   <li><b>H2 in standard mode</b>: SQL-standard {@code MERGE INTO … WHEN NOT MATCHED THEN INSERT}
+ *   + {@code UPDATE}. H2 in standard mode does not accept {@code ON CONFLICT} syntax. This path
+ *   is used by downstream modules (e.g. {@code casehub-engine-ledger}) that run tests with a
+ *   plain H2 datasource. Concurrent first-inserts are not safe here — two transactions can race
+ *   for the same new row; but H2 is used only in single-threaded test contexts, not production.
+ *   Production deployments always use PostgreSQL.</li>
+ * </ul>
  *
- * <p><strong>Merkle Serialization Invariant:</strong> the row lock acquired by the UPDATE is held
- * for the duration of the enclosing {@code @Transactional save()} in
- * {@code JpaLedgerEntryRepository}. This serialises the entire save pipeline — including the
- * Merkle frontier update — for concurrent saves to the same {@code (subject, tenancy)} pair.
- * Saves for different {@code (subjectId, tenancyId)} pairs proceed independently.
- * See GE-20260615-6d0ae3 and the concurrent-write-safety spec (issue #100).
+ * <p>Detection queries {@code INFORMATION_SCHEMA.SETTINGS} on H2 to check whether
+ * {@code MODE=PostgreSQL} is active — both H2 modes report {@code "H2"} as the product name,
+ * so {@code getDatabaseProductName()} alone is insufficient. Refs casehubio/ledger#150.
  *
  * <p>Shared by all JPA repositories that persist
  * {@link io.casehub.ledger.runtime.model.LedgerEntry} subclasses.
@@ -41,24 +46,22 @@ class LedgerSequenceAllocator {
     @LedgerPersistenceUnit
     EntityManager em;
 
+    // Cached result of dialect detection — fixed per application lifetime.
+    private volatile Boolean useOnConflict = null;
+
     /**
      * Returns the next contiguous sequence number for the given {@code (subjectId, tenancyId)} pair.
      *
-     * <p>The INSERT seeds the row with {@code next_seq = 1} on first use; the UPDATE increments it.
-     * After the UPDATE, {@code next_seq} holds the allocated value + 1; the SELECT returns
-     * {@code next_seq - 1} (the allocated sequence number). First allocation returns 1.
-     *
-     * <p>{@code CAST(?1 AS UUID)} is required: both H2 and PostgreSQL require an explicit cast
-     * to coerce the JDBC parameter to the UUID column type.
+     * <p>First allocation for a pair returns 1. Subsequent calls increment monotonically.
+     * {@code CAST(?1 AS UUID)} is required for both H2 and PostgreSQL to coerce the JDBC
+     * parameter to the UUID column type.
      */
     int nextSequenceNumber(final UUID subjectId, final String tenancyId) {
-        em.createNativeQuery(
-                "INSERT INTO ledger_subject_sequence (subject_id, tenancy_id, next_seq) " +
-                "VALUES (CAST(?1 AS UUID), ?2, 1) " +
-                "ON CONFLICT DO NOTHING")
-                .setParameter(1, subjectId)
-                .setParameter(2, tenancyId)
-                .executeUpdate();
+        if (useOnConflictSyntax()) {
+            onConflictInsert(subjectId, tenancyId);
+        } else {
+            mergeInsert(subjectId, tenancyId);
+        }
         em.createNativeQuery(
                 "UPDATE ledger_subject_sequence " +
                 "SET next_seq = next_seq + 1 " +
@@ -66,7 +69,7 @@ class LedgerSequenceAllocator {
                 .setParameter(1, subjectId)
                 .setParameter(2, tenancyId)
                 .executeUpdate();
-        em.flush(); // flush before SELECT reads the result within the same transaction
+        em.flush();
         final Number nextSeq = (Number) em.createNativeQuery(
                 "SELECT next_seq - 1 FROM ledger_subject_sequence " +
                 "WHERE subject_id = ?1 AND tenancy_id = ?2")
@@ -74,5 +77,56 @@ class LedgerSequenceAllocator {
                 .setParameter(2, tenancyId)
                 .getSingleResult();
         return nextSeq.intValue();
+    }
+
+    private void onConflictInsert(final UUID subjectId, final String tenancyId) {
+        em.createNativeQuery(
+                "INSERT INTO ledger_subject_sequence (subject_id, tenancy_id, next_seq) " +
+                "VALUES (CAST(?1 AS UUID), ?2, 1) " +
+                "ON CONFLICT DO NOTHING")
+                .setParameter(1, subjectId)
+                .setParameter(2, tenancyId)
+                .executeUpdate();
+    }
+
+    private void mergeInsert(final UUID subjectId, final String tenancyId) {
+        // SQL-standard MERGE: inserts the row only when no match exists.
+        // CAST(?2 AS VARCHAR) avoids H2 misinterpreting the alias as a type name.
+        em.createNativeQuery(
+                "MERGE INTO ledger_subject_sequence AS t " +
+                "USING (SELECT CAST(?1 AS UUID) AS sid, CAST(?2 AS VARCHAR) AS tval) AS s " +
+                "ON t.subject_id = s.sid AND t.tenancy_id = s.tval " +
+                "WHEN NOT MATCHED THEN INSERT (subject_id, tenancy_id, next_seq) VALUES (s.sid, s.tval, 1)")
+                .setParameter(1, subjectId)
+                .setParameter(2, tenancyId)
+                .executeUpdate();
+    }
+
+    private boolean useOnConflictSyntax() {
+        Boolean result = useOnConflict;
+        if (result == null) {
+            result = em.unwrap(Session.class).doReturningWork(conn -> {
+                final String productName = conn.getMetaData().getDatabaseProductName()
+                        .toLowerCase(Locale.ROOT);
+                if (productName.contains("postgresql")) {
+                    return true; // real PostgreSQL
+                }
+                if (!productName.contains("h2")) {
+                    return false; // unknown DB — safe default: use MERGE
+                }
+                // H2: ON CONFLICT is only supported when MODE=PostgreSQL is active.
+                // getURL() may omit connection properties, so query INFORMATION_SCHEMA directly.
+                try (var stmt = conn.createStatement();
+                     var rs = stmt.executeQuery(
+                         "SELECT SETTING_VALUE FROM INFORMATION_SCHEMA.SETTINGS " +
+                         "WHERE SETTING_NAME = 'MODE'")) {
+                    return rs.next() && "PostgreSQL".equalsIgnoreCase(rs.getString(1));
+                } catch (final Exception ignored) {
+                    return false; // older H2 or schema unavailable — use MERGE
+                }
+            });
+            useOnConflict = result;
+        }
+        return result;
     }
 }

--- a/runtime/src/main/resources/db/ledger/migration/V1010__erasure_receipt_entry.sql
+++ b/runtime/src/main/resources/db/ledger/migration/V1010__erasure_receipt_entry.sql
@@ -1,0 +1,16 @@
+-- CaseHub Ledger V1009 — erasure receipt entry
+-- Records tamper-evident GDPR Art.17 erasure events in the Merkle chain.
+-- Opt-in: casehub.ledger.erasure.receipt.enabled=true (default false).
+-- Compatible with H2 (dev/test) and PostgreSQL (production).
+
+CREATE TABLE erasure_receipt_entry (
+    id                   UUID         NOT NULL,
+    erased_actor_id      TEXT         NOT NULL,
+    erasure_reason       VARCHAR(50)  NOT NULL,
+    affected_entry_count BIGINT       NOT NULL DEFAULT 0,
+    mapping_found        BOOLEAN      NOT NULL DEFAULT FALSE,
+    CONSTRAINT pk_erasure_receipt_entry PRIMARY KEY (id),
+    CONSTRAINT fk_erasure_receipt_ledger FOREIGN KEY (id) REFERENCES ledger_entry(id)
+);
+
+CREATE INDEX idx_erasure_receipt_erased_actor ON erasure_receipt_entry (erased_actor_id);

--- a/runtime/src/test/java/io/casehub/ledger/FlywayLocationContractTest.java
+++ b/runtime/src/test/java/io/casehub/ledger/FlywayLocationContractTest.java
@@ -26,8 +26,8 @@ class FlywayLocationContractTest {
 
         assertThat(result.success).isTrue();
         assertThat(result.migrationsExecuted)
-                .as("expected all 10 ledger base migrations (V1000-V1009)")
-                .isEqualTo(10);
+                .as("expected all 11 ledger base migrations (V1000-V1010)")
+                .isEqualTo(11);
     }
 
     @Test

--- a/runtime/src/test/java/io/casehub/ledger/privacy/LedgerErasureReceiptIT.java
+++ b/runtime/src/test/java/io/casehub/ledger/privacy/LedgerErasureReceiptIT.java
@@ -1,0 +1,132 @@
+package io.casehub.ledger.privacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.Test;
+
+import io.casehub.ledger.api.model.ErasureReason;
+import io.casehub.ledger.api.model.LedgerEntryType;
+import io.casehub.ledger.runtime.model.ErasureReceiptLedgerEntry;
+import io.casehub.ledger.runtime.privacy.LedgerErasureService;
+import io.casehub.ledger.runtime.privacy.LedgerErasureService.ErasureResult;
+import io.casehub.ledger.runtime.repository.ErasureReceiptRepository;
+import io.casehub.ledger.runtime.repository.LedgerEntryRepository;
+import io.casehub.ledger.service.supplement.TestEntry;
+import io.casehub.platform.api.identity.ActorType;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import static io.casehub.platform.api.identity.TenancyConstants.DEFAULT_TENANT_ID;
+
+/**
+ * Integration tests for the opt-in erasure receipt feature (ledger#140).
+ *
+ * <p>Verifies that {@link LedgerErasureService} writes an {@link ErasureReceiptLedgerEntry}
+ * when {@code casehub.ledger.erasure.receipt.enabled=true}, and that the receipt is
+ * queryable via {@link ErasureReceiptRepository}.
+ */
+@QuarkusTest
+@TestProfile(LedgerErasureReceiptIT.ErasureReceiptProfile.class)
+class LedgerErasureReceiptIT {
+
+    public static class ErasureReceiptProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "erasure-receipt-test";
+        }
+    }
+
+    @Inject
+    LedgerErasureService erasureService;
+
+    @Inject
+    ErasureReceiptRepository receiptRepo;
+
+    @Inject
+    LedgerEntryRepository repo;
+
+    // ── Happy path: receipt written on successful erasure ─────────────────────
+
+    @Test
+    @Transactional
+    void erase_withReceiptEnabled_resultCarriesReceiptEntryId() {
+        final String actorId = "actor-" + UUID.randomUUID();
+        saveEntry(actorId);
+
+        final ErasureResult result = erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
+
+        assertThat(result.receiptEntryId()).isPresent();
+    }
+
+    @Test
+    @Transactional
+    void erase_receipt_storedWithCorrectFields() {
+        final String actorId = "actor-" + UUID.randomUUID();
+        saveEntry(actorId);
+        saveEntry(actorId);
+
+        final ErasureResult result = erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
+
+        final List<ErasureReceiptLedgerEntry> receipts =
+                receiptRepo.findByErasedActorId(actorId, DEFAULT_TENANT_ID);
+
+        assertThat(receipts).hasSize(1);
+        final ErasureReceiptLedgerEntry receipt = receipts.get(0);
+        assertThat(receipt.id).isEqualTo(result.receiptEntryId().orElseThrow());
+        assertThat(receipt.erasedActorId).isEqualTo(actorId);
+        assertThat(receipt.erasureReason).isEqualTo(ErasureReason.GDPR_ART_17_REQUEST);
+        assertThat(receipt.affectedEntryCount).isEqualTo(2L);
+        assertThat(receipt.mappingFound).isTrue();
+        assertThat(receipt.entryType).isEqualTo(LedgerEntryType.EVENT);
+        assertThat(receipt.tenancyId).isEqualTo(DEFAULT_TENANT_ID);
+    }
+
+    @Test
+    @Transactional
+    void erase_unknownActor_noMappingFound_receiptStillWritten() {
+        final String actorId = "unknown-" + UUID.randomUUID();
+
+        final ErasureResult result = erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
+
+        assertThat(result.mappingFound()).isFalse();
+        assertThat(result.receiptEntryId()).isPresent();
+
+        final List<ErasureReceiptLedgerEntry> receipts =
+                receiptRepo.findByErasedActorId(actorId, DEFAULT_TENANT_ID);
+        assertThat(receipts).hasSize(1);
+        assertThat(receipts.get(0).mappingFound).isFalse();
+        assertThat(receipts.get(0).affectedEntryCount).isEqualTo(0L);
+    }
+
+    @Test
+    @Transactional
+    void erase_multipleErasures_receiptPerCall() {
+        final String actorId = "actor-" + UUID.randomUUID();
+        saveEntry(actorId);
+
+        erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
+        erasureService.erase(actorId, ErasureReason.ACCOUNT_DELETION);
+
+        final List<ErasureReceiptLedgerEntry> receipts =
+                receiptRepo.findByErasedActorId(actorId, DEFAULT_TENANT_ID);
+        assertThat(receipts).hasSize(2);
+    }
+
+    // ── Fixture ───────────────────────────────────────────────────────────────
+
+    private void saveEntry(final String actorId) {
+        final TestEntry e = new TestEntry();
+        e.subjectId = UUID.randomUUID();
+        e.entryType = LedgerEntryType.EVENT;
+        e.actorId = actorId;
+        e.actorType = ActorType.HUMAN;
+        e.actorRole = "tester";
+        repo.save(e, DEFAULT_TENANT_ID);
+    }
+}

--- a/runtime/src/test/java/io/casehub/ledger/privacy/LedgerErasureServiceIT.java
+++ b/runtime/src/test/java/io/casehub/ledger/privacy/LedgerErasureServiceIT.java
@@ -12,6 +12,7 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 
 import io.casehub.platform.api.identity.ActorType;
+import io.casehub.ledger.api.model.ErasureReason;
 import io.casehub.ledger.api.model.LedgerEntryType;
 import io.casehub.ledger.runtime.privacy.LedgerErasureService;
 import io.casehub.ledger.runtime.privacy.LedgerErasureService.ErasureResult;
@@ -45,7 +46,7 @@ class LedgerErasureServiceIT {
         saveEntry(actorId);
         saveEntry(actorId);
 
-        final ErasureResult result = erasureService.erase(actorId);
+        final ErasureResult result = erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
 
         assertThat(result.rawActorId()).isEqualTo(actorId);
         assertThat(result.mappingFound()).isTrue();
@@ -57,7 +58,7 @@ class LedgerErasureServiceIT {
     @Test
     @Transactional
     void erase_unknownActor_mappingNotFound_zeroCount() {
-        final ErasureResult result = erasureService.erase("never-saved-" + UUID.randomUUID());
+        final ErasureResult result = erasureService.erase("never-saved-" + UUID.randomUUID(), ErasureReason.GDPR_ART_17_REQUEST);
 
         assertThat(result.mappingFound()).isFalse();
         assertThat(result.affectedEntryCount()).isZero();
@@ -76,7 +77,7 @@ class LedgerErasureServiceIT {
 
         assertThat(repo.findByActorId(actorId, from, to, DEFAULT_TENANT_ID)).hasSize(1);
 
-        erasureService.erase(actorId);
+        erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
 
         assertThat(repo.findByActorId(actorId, from, to, DEFAULT_TENANT_ID)).isEmpty();
     }
@@ -89,8 +90,8 @@ class LedgerErasureServiceIT {
         final String actorId = "double-erase-" + UUID.randomUUID();
         saveEntry(actorId);
 
-        erasureService.erase(actorId);
-        final ErasureResult second = erasureService.erase(actorId);
+        erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
+        final ErasureResult second = erasureService.erase(actorId, ErasureReason.GDPR_ART_17_REQUEST);
 
         assertThat(second.mappingFound()).isFalse();
         assertThat(second.affectedEntryCount()).isZero();
@@ -103,7 +104,7 @@ class LedgerErasureServiceIT {
     void erase_systemActor_neverTokenised_mappingNotFound() {
         saveEntry("system:health-check", ActorType.SYSTEM);
 
-        final ErasureResult result = erasureService.erase("system:health-check");
+        final ErasureResult result = erasureService.erase("system:health-check", ErasureReason.GDPR_ART_17_REQUEST);
 
         assertThat(result.mappingFound()).isFalse();
         assertThat(result.affectedEntryCount()).isZero();

--- a/runtime/src/test/java/io/casehub/ledger/privacy/LedgerPrivacyProducerTest.java
+++ b/runtime/src/test/java/io/casehub/ledger/privacy/LedgerPrivacyProducerTest.java
@@ -1,0 +1,82 @@
+package io.casehub.ledger.privacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.casehub.ledger.api.spi.ActorIdentityProvider;
+import io.casehub.ledger.runtime.config.LedgerConfig;
+import io.casehub.ledger.runtime.privacy.InternalActorIdentityProvider;
+import io.casehub.ledger.runtime.privacy.LedgerPrivacyProducer;
+import io.casehub.ledger.runtime.privacy.PassThroughActorIdentityProvider;
+
+/**
+ * Unit tests for {@link LedgerPrivacyProducer}.
+ *
+ * <p>
+ * Verifies that the producer never accesses the {@link EntityManager} when
+ * tokenisation is disabled — the critical invariant that allows the producer
+ * to operate in datasource-free deployments (e.g. apps using casehub-qhorus
+ * without a ledger JPA datasource).
+ */
+@ExtendWith(MockitoExtension.class)
+class LedgerPrivacyProducerTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    LedgerConfig config;
+
+    @SuppressWarnings("unchecked")
+    @Mock
+    Instance<EntityManager> emInstance;
+
+    @Test
+    void actorIdentityProvider_tokenisationDisabled_returnsPassThrough_withoutAccessingEntityManager() {
+        when(config.identity().tokenisation().enabled()).thenReturn(false);
+
+        final ActorIdentityProvider result = producer().actorIdentityProvider();
+
+        assertThat(result).isInstanceOf(PassThroughActorIdentityProvider.class);
+        verify(emInstance, never()).get();
+    }
+
+    @Test
+    void actorIdentityProvider_tokenisationEnabled_returnsInternal_andAccessesEntityManager() {
+        when(config.identity().tokenisation().enabled()).thenReturn(true);
+        when(emInstance.get()).thenReturn(mock(EntityManager.class));
+
+        final ActorIdentityProvider result = producer().actorIdentityProvider();
+
+        assertThat(result).isInstanceOf(InternalActorIdentityProvider.class);
+        verify(emInstance).get();
+    }
+
+    private LedgerPrivacyProducer producer() {
+        final LedgerPrivacyProducer p = new LedgerPrivacyProducer();
+        set(p, "config", config);
+        set(p, "emInstance", emInstance);
+        return p;
+    }
+
+    private static void set(final Object target, final String name, final Object value) {
+        try {
+            final Field f = target.getClass().getDeclaredField(name);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (final ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/runtime/src/test/java/io/casehub/ledger/runtime/persistence/LedgerEntityManagerProducerTest.java
+++ b/runtime/src/test/java/io/casehub/ledger/runtime/persistence/LedgerEntityManagerProducerTest.java
@@ -175,6 +175,11 @@ class LedgerEntityManagerProducerTest {
         public AgentIdentityConfig agentIdentity() {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public ErasureReceiptConfig erasureReceipt() {
+            throw new UnsupportedOperationException();
+        }
     }
 
     private LedgerEntityManagerProducer producerWith(final LedgerConfig config) {

--- a/runtime/src/test/java/io/casehub/ledger/runtime/repository/jpa/JpaSequenceNumberH2StandardIT.java
+++ b/runtime/src/test/java/io/casehub/ledger/runtime/repository/jpa/JpaSequenceNumberH2StandardIT.java
@@ -1,0 +1,79 @@
+package io.casehub.ledger.runtime.repository.jpa;
+
+import static io.casehub.platform.api.identity.TenancyConstants.DEFAULT_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import io.casehub.ledger.api.model.LedgerEntryType;
+import io.casehub.ledger.runtime.model.LedgerEntry;
+import io.casehub.ledger.runtime.repository.LedgerEntryRepository;
+import io.casehub.ledger.service.supplement.TestEntry;
+import io.casehub.platform.api.identity.ActorType;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Proves that {@link LedgerSequenceAllocator} works with plain H2 (no {@code MODE=PostgreSQL}).
+ *
+ * <p>This is a regression guard for casehubio/ledger#150: downstream modules that consume
+ * {@code casehub-ledger} and run tests with a default H2 datasource (e.g.
+ * {@code casehub-engine-ledger}) must not fail with an {@code ON CONFLICT DO NOTHING} syntax
+ * error. The allocator must detect the H2 dialect and use the SQL-standard MERGE path instead.
+ */
+@QuarkusTest
+@TestProfile(JpaSequenceNumberH2StandardIT.Profile.class)
+class JpaSequenceNumberH2StandardIT {
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "sequence-number-h2-standard-test";
+        }
+    }
+
+    @Inject
+    LedgerEntryRepository repo;
+
+    @Test
+    void sequentialSavesProduceContiguousSequenceNumbers_inH2StandardMode() {
+        final UUID subjectId = UUID.randomUUID();
+
+        final LedgerEntry e1 = repo.save(entry(subjectId), DEFAULT_TENANT_ID);
+        final LedgerEntry e2 = repo.save(entry(subjectId), DEFAULT_TENANT_ID);
+        final LedgerEntry e3 = repo.save(entry(subjectId), DEFAULT_TENANT_ID);
+
+        assertThat(List.of(e1.sequenceNumber, e2.sequenceNumber, e3.sequenceNumber))
+                .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void perSubjectSequencesAreIndependent_inH2StandardMode() {
+        final UUID subjectA = UUID.randomUUID();
+        final UUID subjectB = UUID.randomUUID();
+
+        final LedgerEntry a1 = repo.save(entry(subjectA), DEFAULT_TENANT_ID);
+        final LedgerEntry b1 = repo.save(entry(subjectB), DEFAULT_TENANT_ID);
+        final LedgerEntry a2 = repo.save(entry(subjectA), DEFAULT_TENANT_ID);
+
+        assertThat(a1.sequenceNumber).isEqualTo(1);
+        assertThat(b1.sequenceNumber).isEqualTo(1);
+        assertThat(a2.sequenceNumber).isEqualTo(2);
+    }
+
+    private TestEntry entry(final UUID subjectId) {
+        final TestEntry e = new TestEntry();
+        e.subjectId = subjectId;
+        e.entryType = LedgerEntryType.EVENT;
+        e.actorId = "test-actor";
+        e.actorType = ActorType.SYSTEM;
+        e.actorRole = "tester";
+        return e;
+    }
+}

--- a/runtime/src/test/resources/application.properties
+++ b/runtime/src/test/resources/application.properties
@@ -212,3 +212,10 @@ casehub.ledger.trust-score.enabled=false
 # Isolated DB — verifies that binding entries maintain the Merkle frontier (#144 regression guard).
 # Inherits the default selected-alternatives block (all four JPA repos active); see lines 4–8.
 %identity-binding-merkle-test.quarkus.datasource.jdbc.url=jdbc:h2:mem:identitybindingmerkletestdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+
+# H2 standard-mode sequence test profile (used by JpaSequenceNumberH2StandardIT)
+# Deliberately omits MODE=PostgreSQL — proves LedgerSequenceAllocator works without it.
+# Regression guard for casehubio/ledger#150: downstream consumers (e.g. casehub-engine-ledger)
+# that use plain H2 must not get SQL syntax errors from ON CONFLICT DO NOTHING.
+%sequence-number-h2-standard-test.quarkus.datasource.jdbc.url=jdbc:h2:mem:seqh2standardtestdb;DB_CLOSE_DELAY=-1
+%sequence-number-h2-standard-test.casehub.ledger.hash-chain.enabled=false

--- a/runtime/src/test/resources/application.properties
+++ b/runtime/src/test/resources/application.properties
@@ -213,6 +213,18 @@ casehub.ledger.trust-score.enabled=false
 # Inherits the default selected-alternatives block (all four JPA repos active); see lines 4–8.
 %identity-binding-merkle-test.quarkus.datasource.jdbc.url=jdbc:h2:mem:identitybindingmerkletestdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
 
+# Erasure receipt test profile (used by LedgerErasureReceiptIT)
+# Isolated DB — tokenisation + receipt writing both enabled; JpaErasureReceiptRepository active
+%erasure-receipt-test.quarkus.datasource.jdbc.url=jdbc:h2:mem:erasurereceipttestdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+%erasure-receipt-test.casehub.ledger.identity.tokenisation.enabled=true
+%erasure-receipt-test.casehub.ledger.erasure-receipt.enabled=true
+%erasure-receipt-test.quarkus.arc.selected-alternatives=\
+  io.casehub.ledger.runtime.repository.jpa.JpaLedgerEntryRepository,\
+  io.casehub.ledger.runtime.repository.jpa.JpaLedgerMerkleFrontierRepository,\
+  io.casehub.ledger.runtime.repository.jpa.JpaActorIdentityBindingRepository,\
+  io.casehub.ledger.runtime.repository.jpa.JpaActorTrustScoreRepository,\
+  io.casehub.ledger.runtime.repository.jpa.JpaErasureReceiptRepository
+
 # H2 standard-mode sequence test profile (used by JpaSequenceNumberH2StandardIT)
 # Deliberately omits MODE=PostgreSQL — proves LedgerSequenceAllocator works without it.
 # Regression guard for casehubio/ledger#150: downstream consumers (e.g. casehub-engine-ledger)


### PR DESCRIPTION
## Summary

Three issues on one branch — two bug fixes and one foundation feature.

**#149 — `LedgerPrivacyProducer`: CDI failure in datasource-free deployments**
`LedgerPrivacyProducer` injected `@LedgerPersistenceUnit EntityManager` eagerly. Apps using `casehub-qhorus` (or any ledger consumer) without a configured JPA datasource got `UnsatisfiedResolutionException` on `ActorIdentityProvider` at startup. Fix: change to `Instance<EntityManager>` — always satisfiable by Arc; `get()` only called when `casehub.ledger.identity.tokenisation.enabled=true`.

**#150 — `LedgerSequenceAllocator`: H2 standard-mode incompatibility**
The #148 fix unified to `INSERT ON CONFLICT DO NOTHING`, which requires `MODE=PostgreSQL` in H2. `casehub-engine-ledger` and other downstream consumers that test with plain H2 (no PostgreSQL mode) got `JdbcSQLSyntaxErrorException` on every ledger write — 18 failures in engine CI. Fix: restore dialect detection via `INFORMATION_SCHEMA.SETTINGS`; H2 standard mode gets SQL-standard `MERGE WHEN NOT MATCHED THEN INSERT + UPDATE`. Real PostgreSQL and H2+`MODE=PostgreSQL` continue using `ON CONFLICT DO NOTHING`.

**#140 — `ErasureReceiptLedgerEntry`: tamper-evident GDPR Art.17 erasure record (foundation)**
Promotes the erasure receipt from devtown-specific to `casehub-ledger` foundation. Opt-in via `casehub.ledger.erasure-receipt.enabled=true` (default `false`). When enabled, `LedgerErasureService.erase()` writes an `ErasureReceiptLedgerEntry` in the same transaction — the act of forgetting is itself part of the Merkle chain. `ErasureResult` gains `Optional<UUID> receiptEntryId`. `ErasureReceiptRepository` SPI + NoOp + JPA + InMemory impls. `ErasureReason` enum: `GDPR_ART_17_REQUEST`, `RETENTION_EXPIRED`, `ACCOUNT_DELETION`. V1010 migration. devtown migration tracked in casehub-devtown#82.

## Test plan

- [ ] 810 runtime tests green (includes 2 new H2-standard-mode tests, 4 new erasure receipt tests, 2 new CDI producer unit tests)
- [ ] 58 persistence-memory tests green
- [ ] `JpaSequenceNumberConcurrentH2IT` still uses `ON CONFLICT DO NOTHING` path (MODE=PostgreSQL detected via INFORMATION_SCHEMA)
- [ ] `JpaSequenceNumberH2StandardIT` proves MERGE path works without MODE=PostgreSQL

Closes #149
Closes #150
Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)